### PR TITLE
Corrupt frame handling in reassembly

### DIFF
--- a/depacketize_science_frames.py
+++ b/depacketize_science_frames.py
@@ -86,7 +86,10 @@ def main():
         try:
             frame_binary = processor.read_frame()
             frame = Frame(frame_binary)
-            frame.save(frames_dir)
+            if frame.corrupt_name in processor.corrupt_frames:
+                frame.save(frames_dir, corrupt=True)
+            else:
+                frame.save(frames_dir, corrupt=False)
             frame_count += 1
         except EOFError:
             break

--- a/emit_sds_l1a/frame.py
+++ b/emit_sds_l1a/frame.py
@@ -158,6 +158,14 @@ class Frame:
         self.instrument_mode_desc = "No match" if self.instrument_mode == "no_match" else \
             INSTRUMENT_MODES[self.instrument_mode]["desc"]
 
+        # Frame name and also corrupt name if needed
+        self.name = "_".join([str(self.dcid).zfill(10), self.start_time.strftime("%Y%m%dt%H%M%S"),
+                          str(self.frame_count_in_acq).zfill(5), str(self.planned_num_frames).zfill(5),
+                          str(self.acq_status), str(self.processed_flag)])
+        self.corrupt_name = "_".join([str(self.dcid).zfill(10), self.start_time.strftime("%Y%m%dt%H%M%S"),
+                              str(self.frame_count_in_acq).zfill(5), str(self.planned_num_frames).zfill(5),
+                              str(9), str(self.processed_flag)])
+
         logger.debug(f"Initialized frame: {self}")
 
     def __repr__(self):
@@ -218,12 +226,11 @@ class Frame:
                      f"Computed checksum: {self._compute_hdr_checksum()}")
         return is_valid
 
-    def save(self, out_dir):
-        fname = "_".join([str(self.dcid).zfill(10), self.start_time.strftime("%Y%m%dt%H%M%S"),
-                          str(self.frame_count_in_acq).zfill(5), str(self.planned_num_frames).zfill(5),
-                          str(self.acq_status), str(self.processed_flag)])
-
-        out_path = os.path.join(out_dir, fname)
+    def save(self, out_dir, corrupt=False):
+        if corrupt:
+            out_path = os.path.join(out_dir, self.corrupt_name)
+        else:
+            out_path = os.path.join(out_dir, self.name)
 
         logger.info("Writing frame to path %s" % out_path)
         logger.debug("data length is %s" % len(self.data))


### PR DESCRIPTION
* During depacketization write out corrupt frames with a "9" as the acquisition status
* During reassembly, if data is compressed then don't try to decompress the corrupt frames.  Just track and report on them.